### PR TITLE
Add a requirements.txt which pulls in the python modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+websocket-client
+py-radix


### PR DESCRIPTION
Went to use the code, but installed `websocket` instead of `websocket-client` which led to some confusion. This provides a requirements.txt which pulls in the required python modules.