### PR TITLE
Fix typo in metadata2 key

### DIFF
--- a/ripe-stream.py
+++ b/ripe-stream.py
@@ -25,7 +25,7 @@ with open(prefix_file) as fp:
 
         rnode = tree.add(prefix)
         rnode.data['metadata'] = metadata
-        rnode.data['metaadta2'] = metadata2
+        rnode.data['metadata2'] = metadata2
 
         ## fetch another line
         line = fp.readline()


### PR DESCRIPTION
Fixes the key 'metadata2' match its use later on